### PR TITLE
Parcialmente fix #23

### DIFF
--- a/app/Http/Controllers/AssociadoController.php
+++ b/app/Http/Controllers/AssociadoController.php
@@ -11,7 +11,7 @@ class AssociadoController extends Controller
     public function index(Request $request) 
     {
         $this->authorize('admin');
-        #Campo de busca
+        // Campo de busca
         if(isset(request()->search)){
             $associados = Associado::where('name','LIKE',"%{$request->search}%")
                          ->orWhere('numero_usp','LIKE',"%{$request->search}%")->paginate(5);

--- a/app/Http/Controllers/ParcelaVendaController.php
+++ b/app/Http/Controllers/ParcelaVendaController.php
@@ -4,26 +4,16 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\ParcelaVenda;
-use App\Models\Venda;
 
 class ParcelaVendaController extends Controller
 {
 
-    public function edit(ParcelaVenda $parcela_venda)
+    public function update(ParcelaVenda $parcelaVenda)
     {
         $this->authorize('admin');
+        $parcelaVenda->status = 'Baixado';
+        $parcelaVenda->update();
 
-        return view('vendas.parcela_venda_edit',[
-            'parcela_venda' => $parcela_venda,
-        ]);
-    }
-
-    public function update(Request $request, ParcelaVenda $parcela_venda, Venda $venda)
-    {
-        $this->authorize('admin');
-        $parcela_venda->status = $request->status;
-        $parcela_venda->update();
-
-        return redirect("/vendas/$venda->id");
+        return redirect("/vendas/$parcelaVenda->venda_id");
     }
 }

--- a/app/Http/Controllers/ParcelaVendaController.php
+++ b/app/Http/Controllers/ParcelaVendaController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\ParcelaVenda;
+use App\Models\Venda;
+
+class ParcelaVendaController extends Controller
+{
+
+    public function edit(ParcelaVenda $parcela_venda)
+    {
+        $this->authorize('admin');
+
+        return view('vendas.parcela_venda_edit',[
+            'parcela_venda' => $parcela_venda,
+        ]);
+    }
+
+    public function update(Request $request, ParcelaVenda $parcela_venda, Venda $venda)
+    {
+        $this->authorize('admin');
+        $parcela_venda->status = $request->status;
+        $parcela_venda->update();
+
+        return redirect("/vendas/$venda->id");
+    }
+}

--- a/app/Http/Controllers/VendaController.php
+++ b/app/Http/Controllers/VendaController.php
@@ -23,12 +23,12 @@ class VendaController extends Controller
             $vendas = $vendas->where(function( $query ) use ( $request ){
 
                 // Model: Associado  campo: name
-                $query->where('associados', function (Builder $query) use ($request){
+                $query->orWhereHas('associado', function (Builder $query) use ($request){
                     $query->where('name','LIKE',"%{$request->search}%");
                 })
                 
                 // Model: Conveniado  campos: razao_social, nome_fantasia
-                ->orWhereHas('conveniados', function (Builder $query) use ($request){
+                ->orWhereHas('conveniado', function (Builder $query) use ($request){
                     $query->where('nome_fantasia','LIKE',"%{$request->search}%")
                         ->orWhere('razao_social','LIKE',"%{$request->search}%");
                 }); 

--- a/app/Http/Requests/VendaRequest.php
+++ b/app/Http/Requests/VendaRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Auth;
 
 class VendaRequest extends FormRequest
 {
@@ -23,14 +24,17 @@ class VendaRequest extends FormRequest
      */
     public function rules()
     {
+
+        // verifica se o usuário é um conveniado
+        $conveniado = Auth::user()->conveniados()->first();
+
         return [
-            'conveniado_id' => 'required',
+            'conveniado_id' => isset($conveniado) ? 'nullable' : 'required',
             'associado_id' => 'required',
             'data_venda' => 'required',
             'quantidade_parcelas' => 'required|integer',
             'valor' => 'required|numeric|min:0',
             'descricao' => 'nullable',
-            'status' => 'required',
         ];
     }
 

--- a/app/Observers/VendaObserver.php
+++ b/app/Observers/VendaObserver.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Venda;
+use Auth;
+
+class VendaObserver
+{
+    /**
+     * Handle the Venda "created" event.
+     *
+     * @param  \App\Models\Venda  $venda
+     * @return void
+     */
+
+    public function creating(Venda $venda)
+    {
+
+        // verifica se é um cenário de factory ou não 
+        try {
+
+            // verifica se o usuário é um conveniado
+            $conveniado = Auth::user()->conveniados()->first();
+
+            if (!empty($conveniado)) {
+                $venda->conveniado_id = $conveniado->id;
+            }
+        }
+        finally {return;}
+
+
+    }
+     
+    public function created(Venda $venda)
+    {
+        //
+    }
+
+    /**
+     * Handle the Venda "updated" event.
+     *
+     * @param  \App\Models\Venda  $venda
+     * @return void
+     */
+    public function updated(Venda $venda)
+    {
+        //
+    }
+
+    /**
+     * Handle the Venda "deleted" event.
+     *
+     * @param  \App\Models\Venda  $venda
+     * @return void
+     */
+    public function deleted(Venda $venda)
+    {
+        //
+    }
+
+    /**
+     * Handle the Venda "restored" event.
+     *
+     * @param  \App\Models\Venda  $venda
+     * @return void
+     */
+    public function restored(Venda $venda)
+    {
+        //
+    }
+
+    /**
+     * Handle the Venda "force deleted" event.
+     *
+     * @param  \App\Models\Venda  $venda
+     * @return void
+     */
+    public function forceDeleted(Venda $venda)
+    {
+        //
+    }
+}

--- a/app/Observers/VendaObserver.php
+++ b/app/Observers/VendaObserver.php
@@ -17,18 +17,12 @@ class VendaObserver
     public function creating(Venda $venda)
     {
 
-        // verifica se é um cenário de factory ou não 
-        try {
+        // verifica se o usuário é um conveniado
+        $conveniado = Auth::user()->conveniados()->first();
 
-            // verifica se o usuário é um conveniado
-            $conveniado = Auth::user()->conveniados()->first();
-
-            if (!empty($conveniado)) {
-                $venda->conveniado_id = $conveniado->id;
-            }
+        if (!empty($conveniado)) {
+            $venda->conveniado_id = $conveniado->id;
         }
-        finally {return;}
-
 
     }
      

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,6 +6,9 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use App\Observers\VendaObserver;
+use App\Models\Venda;
+
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -32,6 +35,6 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Venda::observe(VendaObserver::class);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^7.3",
         "barryvdh/laravel-dompdf": "^0.9.0",
+        "doctrine/dbal": "^3.1",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4a18004a5c4ca61469d41e6a4e91d8f",
+    "content-hash": "049b1af92b919b88444eb17e294dcc6a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -173,6 +173,79 @@
             "time": "2021-01-20T22:51:39+00:00"
         },
         {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T07:46:03+00:00"
+        },
+        {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "v0.1.1",
             "source": {
@@ -204,6 +277,350 @@
             ],
             "description": "implementation of xdg base directory specification for php",
             "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "1.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "3bb5588cec00a0268829cc4a518490df6741af9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/3bb5588cec00a0268829cc4a518490df6741af9d",
+                "reference": "3bb5588cec00a0268829cc4a518490df6741af9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4",
+                "psr/cache": ">=3"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^8.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "predis/predis": "~1.0",
+                "psr/cache": "^1.0 || ^2.0",
+                "symfony/cache": "^4.4 || ^5.2"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/1.11.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-25T09:01:55+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "5ba62e7e40df119424866064faf2cef66cb5232a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/5ba62e7e40df119424866064faf2cef66cb5232a",
+                "reference": "5ba62e7e40df119424866064faf2cef66cb5232a",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.11.99",
+                "doctrine/cache": "^1.0",
+                "doctrine/deprecations": "^0.5.3",
+                "doctrine/event-manager": "^1.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "8.2.0",
+                "jetbrains/phpstorm-stubs": "2020.2",
+                "phpstan/phpstan": "0.12.81",
+                "phpstan/phpstan-strict-rules": "^0.12.2",
+                "phpunit/phpunit": "9.5.0",
+                "psalm/plugin-phpunit": "0.13.0",
+                "squizlabs/php_codesniffer": "3.6.0",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
+                "vimeo/psalm": "4.6.4"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-19T17:51:23+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "v0.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0|^7.0|^8.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v0.5.3"
+            },
+            "time": "2021-03-21T12:59:47+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/1.1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T18:28:51+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -7525,5 +7942,5 @@
         "php": "^7.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/laravel-usp-theme.php
+++ b/config/laravel-usp-theme.php
@@ -28,10 +28,10 @@ $vendas =  [
         'text' => 'Listar',
         'url'  => '/vendas',
     ],
-    [
+    /* [
         'text' => 'Cadastrar',
         'url'  => '/vendas/create',
-    ],
+    ], */
 ];
 
 $relatorios =  [

--- a/database/factories/VendaFactory.php
+++ b/database/factories/VendaFactory.php
@@ -31,7 +31,6 @@ class VendaFactory extends Factory
             'quantidade_parcelas' => $this->faker->randomDigit,
             'valor' => $this->faker->numberBetween(0, 1000),
             'descricao' => $this->faker->text,
-            'status' => $this->faker->randomElement($array = array ('A Vencer','Baixado','Vencido')),
         ];
     }
 }

--- a/database/migrations/2021_06_15_114243_change_status_column_in_vendas.php
+++ b/database/migrations/2021_06_15_114243_change_status_column_in_vendas.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeStatusColumnInVendas extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('vendas', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('vendas', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -16,7 +16,7 @@ class UserSeeder extends Seeder
     {
         $user = [
             
-            'name'     => "Unimed do Estado de Sao Paulo",
+            'name'     => "Unimed Fesp",
             'email'    => "contato@usp.br",
             'password' => bcrypt("teste"),
             

--- a/database/seeders/VendaSeeder.php
+++ b/database/seeders/VendaSeeder.php
@@ -14,6 +14,7 @@ class VendaSeeder extends Seeder
      */
     public function run()
     {
+        
         $venda = [
             'conveniado_id' => 1,
             'associado_id' => 1,
@@ -22,7 +23,15 @@ class VendaSeeder extends Seeder
             'valor' => 250,
             'descricao' => 'Compra de uma camiseta',
         ];
-        Venda::create($venda);
-        Venda::factory(20)->create();
+
+        // mutar o VendaObserver
+        Venda::withoutEvents(function () use ($venda) {
+
+            Venda::create($venda);
+            Venda::factory(20)->create();
+
+        });
+
+
     }
 }

--- a/database/seeders/VendaSeeder.php
+++ b/database/seeders/VendaSeeder.php
@@ -21,7 +21,6 @@ class VendaSeeder extends Seeder
             'quantidade_parcelas' => 2,
             'valor' => 250,
             'descricao' => 'Compra de uma camiseta',
-            'status' => 'A Vencer',
         ];
         Venda::create($venda);
         Venda::factory(20)->create();

--- a/resources/views/conveniados/vendas.blade.php
+++ b/resources/views/conveniados/vendas.blade.php
@@ -19,7 +19,7 @@
         @foreach ($vendas as $venda)
         <tr>
           <td><a href="/vendas/{{$venda->id}}">{{$venda->associado->name}}</a></td>
-          <td>{{$venda->data_venda}}</td>
+          <td>{{ $venda->data_venda = implode('/',array_reverse(explode('-',$venda->data_venda))) }}</td>
           <td>{{$venda->quantidade_parcelas}}</td>
           <td>{{$venda->valor}}</td>
           <td>{{$venda->descricao}}</td>

--- a/resources/views/conveniados/vendas.blade.php
+++ b/resources/views/conveniados/vendas.blade.php
@@ -3,7 +3,7 @@
   <table class="table table-striped">
     <thead>
         <tr>
-          <th><h3>Vendas de {{ $conveniado->razao_social }}</h3></th>
+          <th><h3>Vendas de {{ $conveniado->nome_fantasia }}</h3></th>
         </tr>
         <tr> 
           <th><h4>Nome</h4></th>

--- a/resources/views/vendas/form.blade.php
+++ b/resources/views/vendas/form.blade.php
@@ -5,25 +5,21 @@
     <div class="card-body">
 
         <div class="row">
-            <div class="col-sm form-group col-sm-6">
-              <div class="form-group">
-                <label><b>Conveniado: </b></label>
-                    <select class="form-control" name="conveniado_id">
-                      @if($objeto)
-                        <option value="{{ $objeto->id }}" selected>
-                              {{ $objeto->nome_fantasia }}
-                        </option>
-                      @else
-                        @foreach(\App\Models\Conveniado::all() as $conveniado)
-                          <option value="{{ $conveniado->id }}" @if(old('conveniado_id')== $conveniado->id) {{'selected'}} 
-                              @else {{($venda->conveniado_id === $conveniado->id ) ? 'selected' : ''}} @endif>
-                                {{ $conveniado->nome_fantasia }}
-                          </option>
-                        @endforeach
-                      @endif
-                    </select>
-              </div>
-            </div> 
+          @if(!$objeto)
+              <div class="col-sm form-group col-sm-6">
+                <div class="form-group">
+                  <label><b>Conveniado: </b></label>
+                      <select class="form-control" name="conveniado_id">
+                          @foreach(\App\Models\Conveniado::all() as $conveniado)
+                            <option value="{{ $conveniado->id }}" @if(old('conveniado_id')== $conveniado->id) {{'selected'}} 
+                                @else {{($venda->conveniado_id === $conveniado->id ) ? 'selected' : ''}} @endif>
+                                  {{ $conveniado->nome_fantasia }}
+                            </option>
+                          @endforeach
+                      </select>
+                </div>
+              </div> 
+            @endif
 
             <div class="col-sm form-group col-sm-6">
               <div class="form-group">
@@ -72,22 +68,6 @@
                 </div>
             </div>
 
-            <div class="col-sm form-group col-sm-4">
-                <div class="form-group">
-                  <label for="status"><b>Status: </b></label><br>
-                  @if($objeto)
-                    <input type="radio" id="a_vencer" name="status" value="A Vencer" checked>
-                    <label for="a_vencer">A Vencer</label><br>
-                  @else
-                  <input type="radio" id="a_vencer" name="status" value="A Vencer" @if($venda->status == "A Vencer")checked @else {{ old('status') == 'A Vencer' ? 'checked' : ''}}@endif>
-                  <label for="a_vencer">A Vencer</label><br>
-                  <input type="radio" id="baixado" name="status" value="Baixado"  @if($venda->status == "Baixado")checked @else {{ old('status') == 'Baixado' ? 'checked' : ''}}@endif>
-                  <label for="baixado">Baixado</label><br>
-                  <input type="radio" id="vencido" name="status" value="Vencido" @if($venda->status == "Vencido")checked @else {{ old('status') == 'Vencido' ? 'checked' : ''}}@endif>
-                  <label for="vencido">Vencido</label><br>
-                  @endif
-                </div>
-            </div>
         </div> 
     </div>
 </div>

--- a/resources/views/vendas/index.blade.php
+++ b/resources/views/vendas/index.blade.php
@@ -2,12 +2,20 @@
 
 @section('content')
 
+<form method="get" action="/vendas">
+  @include('vendas.partials.search')
+</form>
+
+<br>
+
 <div class="card">
 
   <table class="table table-striped">
       <thead>
         <tr> 
           <th><h3>Venda por Associado</h3></th>
+          <th><h3>Data da venda</h3></th>
+          <th><h3>Conveniado</h3></th>
           <th><h3>Ações</h3></th>
         </tr>
       </thead>
@@ -16,6 +24,8 @@
       @foreach ($vendas as $venda)
           <tr>
             <td><a href="/vendas/{{$venda->id}}">{{ $venda->associado->name }}</a></td>
+            <td>{{ $venda->data_venda = implode('/',array_reverse(explode('-',$venda->data_venda))) }}</td>
+            <td>{{ $venda->conveniado->nome_fantasia }}</td>
             <td>
               
               <form method="POST" action="/vendas/{{ $venda->id }}">

--- a/resources/views/vendas/parcela_venda_edit.blade.php
+++ b/resources/views/vendas/parcela_venda_edit.blade.php
@@ -1,0 +1,28 @@
+@extends('main')
+
+@section('content')
+
+<form method="POST" action="/parcelaVenda/{{ $parcela_venda->id }}"> 
+    @csrf
+    @method('patch')
+    <div class="card">
+        <div class="card-header"><h4><b>Atualizar status da parcela</b></h4></div>
+        <div class="card-body">
+            <div class="col-sm form-group col-sm-4">
+                <div class="form-group">
+                    <input type="radio" id="a_vencer" name="status" value="A Vencer" @if($parcela_venda->status == "A Vencer")checked @else {{ old('status') == 'A Vencer' ? 'checked' : ''}}@endif>
+                    <label for="a_vencer">A Vencer</label><br>
+                    <input type="radio" id="baixado" name="status" value="Baixado"  @if($parcela_venda->status == "Baixado")checked @else {{ old('status') == 'Baixado' ? 'checked' : ''}}@endif>
+                    <label for="baixado">Baixado</label><br>
+                    <input type="radio" id="vencido" name="status" value="Vencido" @if($parcela_venda->status == "Vencido")checked @else {{ old('status') == 'Vencido' ? 'checked' : ''}}@endif>
+                    <label for="vencido">Vencido</label><br>
+                </div>
+            </div>
+            <div class="form-group">
+                <button type="submit" class="btn btn-success">Enviar</button>
+            </div>
+        </div>
+    </div>
+</form>
+
+@endsection

--- a/resources/views/vendas/partials/search.blade.php
+++ b/resources/views/vendas/partials/search.blade.php
@@ -1,0 +1,8 @@
+<div class="row">
+    <div class=" col-sm input-group">
+        <input type="text" class="form-control" name="search" value="{{ request()->search }}">
+        <span class="input-group-btn">
+            <button type="submit" class="btn btn-success"> Buscar </button>
+        </span>
+    </div>
+</div>

--- a/resources/views/vendas/show.blade.php
+++ b/resources/views/vendas/show.blade.php
@@ -27,14 +27,15 @@
                 Quantidade de Parcelas: {{ $venda->quantidade_parcelas }}<br>
                 Valor: {{ $venda->valor }}<br>
                 Descrição: {{ $venda->descricao }}<br>
-                Status: {{ $venda->status }}<br><br>
                 
             </div>
         </div>
 
         <ul>
         @foreach($venda->parcelas as $parcela)
-            <li>R$ {{ $parcela->valor }} - {{ $parcela->datavencto }} - {{ $parcela->status }}</li>
+            <li>
+                R$ {{ $parcela->valor }} - {{ $parcela->datavencto }} - <a href="/parcelaVenda/{{$parcela->id}}/edit">{{ $parcela->status }}</a>
+            </li>
         @endforeach
         </ul>
     </div>

--- a/resources/views/vendas/show.blade.php
+++ b/resources/views/vendas/show.blade.php
@@ -34,7 +34,12 @@
         <ul>
         @foreach($venda->parcelas as $parcela)
             <li>
-                R$ {{ $parcela->valor }} - {{ $parcela->datavencto }} - <a href="/parcelaVenda/{{$parcela->id}}/edit">{{ $parcela->status }}</a>
+                R$ {{ $parcela->valor }} - {{ $parcela->datavencto }} - {{ $parcela->status }} 
+                <form method="POST" action="/parcelaVenda/{{ $parcela->id }}">
+                    @csrf
+                    @method('patch')
+                    <button>Baixar parcela</button>                
+                </form>
             </li>
         @endforeach
         </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ConveniadoController;
 use App\Http\Controllers\VendaController;
 use App\Http\Controllers\RelatorioController;
 use App\Http\Controllers\LoginController;
+use App\Http\Controllers\ParcelaVendaController;
 
 // Home
 Route::get('/', [IndexController::class, 'index']);
@@ -27,6 +28,8 @@ Route::resource('/conveniados', ConveniadoController::class);
 
 // Rotas Vendas
 Route::resource('/vendas', VendaController::class);
+// Atualização do status da parcela
+Route::resource('/parcelaVenda', ParcelaVendaController::class);
 
 // Relatórios
 Route::get('/relatorios/conveniados/{conveniado}', [RelatorioController::class, 'conveniados']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,7 @@ Route::resource('/conveniados', ConveniadoController::class);
 // Rotas Vendas
 Route::resource('/vendas', VendaController::class);
 // Atualização do status da parcela
-Route::resource('/parcelaVenda', ParcelaVendaController::class);
+Route::patch('parcelaVenda/{parcelaVenda}', [ParcelaVendaController::class, 'update']);
 
 // Relatórios
 Route::get('/relatorios/conveniados/{conveniado}', [RelatorioController::class, 'conveniados']);


### PR DESCRIPTION
| O quê                                                        | Feito | Dificuldade             |
| ------------------------------------------------------------ | ----- | ----------------------- |
| Injetar o campo conveniado_id pelo Observer, no formulário da venda do Conveniado | ✔️     |                         |
| Implementar botão para baixar a parcela                      | ✔️     | Declaração de rotas     |
| Tirar campo status da venda do model Venda a partir de uma migration de alteração | ✔️     |                         |
| Modificar status da parcela automaticamente se passar da data de vencimento (colocar como vencido) |       |                         |
| Na listagem das vendas por associado, mostrar o nome do associado, o conveniado e a data da venda | ✔️     |                         |
| Implementar busca para vendas pelo nome do associado ou pelo nome do conveniado enquanto logado como admin | ✔️     | Exception no Controller |
| Implementar busca nas vendas do conveniado por nome do associado (não  pode trazer as compras do associado de outras empresas) enquanto logado  como conveniado |       |                         |
| Trocar opções definidas como razão social para nome fantasia | ✔️     |                         |

### Modificações adicionais

- Retirada da opção "Cadastrar Venda" no submenu do Laravel Theme, pois estava duplicado com a opção de Cadastrar Venda diretamente no menu;
- Modificação dos seeders e factories para retirada do campo "status" na tabela vendas.