### PR TITLE
Indicação para selecionar período na barra de pesquisa por parcelas 

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -38,32 +38,38 @@ class IndexController extends Controller
 
 	    // query
 	    
-	    if ($array_date) $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->paginate(10);
-            else $parcelas = NULL;
+	    if ($array_date) {
+		    $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->paginate(10);
+	    } else $parcelas = NULL;
 	 
             return view ('index-admin', [
               'parcelas'  => $parcelas,
             ]);
-        }
+	}
+
         // índice de qualquer user
         return view ('index');
     }
 
     public function pdf(Request $request)
     {
-
+      $this->authorize('admin');
+      
       // data de vencimento
       $array_date = self::datavencto($request);
 
       // query
 
-      if ($array_date) $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->get();
-      else $parcelas = NULL;
+      if ($array_date) {
+	      $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->get();
+      } else $parcelas = NULL;
 
       $pdf = PDF::loadView('pdf.associados', [
           'parcelas'    => $parcelas,
-      ])->setPaper('a4', 'landscape');
+  ])->setPaper('a4', 'landscape');
+
       return $pdf->download("associados.pdf");
+    
     }
 
     private function datavencto($request)

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -30,11 +30,17 @@ class IndexController extends Controller
                     'vendas'     => isset($vendas) ? $vendas : null,
                 ]);
             }
+
+            // índice do admin
+
+            // data de vencimento
             $array_date = self::datavencto($request);
 
-            // query
-            $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->paginate(10);
-
+	    // query
+	    
+	    if ($array_date) $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->paginate(10);
+            else $parcelas = NULL;
+	 
             return view ('index-admin', [
               'parcelas'  => $parcelas,
             ]);
@@ -45,17 +51,18 @@ class IndexController extends Controller
 
     public function pdf(Request $request)
     {
-      $this->authorize('admin');
 
       // data de vencimento
       $array_date = self::datavencto($request);
 
       // query
-      $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->get();
+
+      if ($array_date) $parcelas = ParcelaVenda::whereBetween('datavencto', $array_date)->get();
+      else $parcelas = NULL;
 
       $pdf = PDF::loadView('pdf.associados', [
           'parcelas'    => $parcelas,
-        ])->setPaper('a4', 'landscape');
+      ])->setPaper('a4', 'landscape');
       return $pdf->download("associados.pdf");
     }
 
@@ -66,11 +73,9 @@ class IndexController extends Controller
         $start_date = Carbon::createFromFormat('d/m/Y', $request->start_date)->format('Y-m-d');
         $end_date = Carbon::createFromFormat('d/m/Y', $request->end_date)->format('Y-m-d');
       } else {
-        $start_date = Carbon::now();
-        $end_date = $start_date;
+            return NULL;	
       }
 
       return [$start_date, $end_date];
     }
-    
 }

--- a/app/Http/Controllers/RelatorioController.php
+++ b/app/Http/Controllers/RelatorioController.php
@@ -16,7 +16,7 @@ class RelatorioController extends Controller
 {
     public function conveniados(Request $request, $conveniado_id)
     {
-        $this->authorize('conveniado.owner', $conveniado_id);
+        $this->authorize('conveniado');
 
         $conveniado = Conveniado::where('id',$conveniado_id)->first();
 
@@ -32,9 +32,10 @@ class RelatorioController extends Controller
     public function pdf(Request $request, $conveniado_id)
     {
 
-      $this->authorize('conveniado.owner', $conveniado_id);
-      
+      $this->authorize('conveniado');
+
       $conveniado = Conveniado::where('id',$conveniado_id)->first();
+
       $parcelas = self::query($request, $conveniado_id);
 
       $pdf = PDF::loadView('pdf.conveniados', [
@@ -49,23 +50,26 @@ class RelatorioController extends Controller
     {
 
       // data de vencimento
-      if($request->start_date and $request->end_date) {
+      if ($request->start_date and $request->end_date) {
         $start_date = Carbon::createFromFormat('d/m/Y', $request->start_date)->format('Y-m-d');
         $end_date = Carbon::createFromFormat('d/m/Y', $request->end_date)->format('Y-m-d');
-      } else {
-        $start_date = Carbon::now();
-        $end_date = $start_date;
-      }
 
-      // filtro para Conveniado
-      $parcelas = DB::table('parcela_vendas')
-      ->select('parcela_vendas.id')
-      ->join('vendas', 'parcela_vendas.venda_id', '=', 'vendas.id')
-      ->where('conveniado_id', $conveniado_id)
-      ->whereBetween('datavencto', [$start_date, $end_date])->get();
+        // filtro para Conveniado
+        $parcelas = DB::table('parcela_vendas')
+        ->select('parcela_vendas.id')
+        ->join('vendas', 'parcela_vendas.venda_id', '=', 'vendas.id')
+        ->where('conveniado_id', $conveniado_id)
+        ->whereBetween('datavencto', [$start_date, $end_date])->get();
 
-      $parcelas = ParcelaVenda::whereIn('id', $parcelas->pluck('id'))->get();
+        $parcelas = ParcelaVenda::whereIn('id', $parcelas->pluck('id'))->get();
 
-      return $parcelas;
+        
+        } else {
+
+	    $parcelas = NULL;
+	
+	}
+      
+        return $parcelas;
     }
 }

--- a/app/Http/Controllers/RelatorioController.php
+++ b/app/Http/Controllers/RelatorioController.php
@@ -16,9 +16,10 @@ class RelatorioController extends Controller
 {
     public function conveniados(Request $request, $conveniado_id)
     {
-        $this->authorize('conveniado');
 
-        $conveniado = Conveniado::where('id',$conveniado_id)->first();
+        $this->authorize('conveniado.owner', $conveniado_id);
+	
+	$conveniado = Conveniado::where('id',$conveniado_id)->first();
 
         $parcelas = self::query($request, $conveniado_id);
 
@@ -32,7 +33,7 @@ class RelatorioController extends Controller
     public function pdf(Request $request, $conveniado_id)
     {
 
-      $this->authorize('conveniado');
+      $this->authorize('conveniado.owner', $conveniado_id);
 
       $conveniado = Conveniado::where('id',$conveniado_id)->first();
 

--- a/resources/views/index-admin.blade.php
+++ b/resources/views/index-admin.blade.php
@@ -1,54 +1,110 @@
 @extends('main')
 
 @section('content')
-  @can('admin')
-  <div class="card">
-    <form method="get" action="/">
-      @include('partials.parcelas-search')
-    </form>
-    <div class="card-header">
-      <a href="/relatorios/associados?start_date={{ request()->start_date }}
-      &end_date={{ request()->end_date }}">
-      <i class="fas fa-file-pdf"></i> Exportar Relatório PDF</a>
-    </div>
-    <table class="table table-striped">
-      <thead>
-          <tr>
-            <th><h4>Baixar</h4></th>
-            <th><h4>Nome</h4></th>
-            <th><h4>Data</h4></th>
-            <th><h4>Valor</h4></th>
-            <th><h4>Conveniado</h4></th>
-            <th><h4>Status</h4></th>
-          </tr>
-      </thead>
-      <tbody>
-        @forelse ($parcelas as $parcela)
-          <tr>
-            <td>
-              @can('admin')
-                @if( $parcela->status != "Baixado")
-                  <form method="POST" action="/parcelaVenda/{{ $parcela->id }}">
-                      @csrf
-                      @method('patch')
-                      <button class="btn btn-primary" onclick="return confirm('Tem certeza que deseja baixar a parcela?');">Baixar parcela</button>
-                  </form>
-                @endif
-              @endcan
-            </td>
-            <td>{{ $parcela->venda->associado->name }}</td>
-            <td>{{ $parcela->datavencto }}</td>
-            <td>{{ $parcela->valor }}</td>
-            <td>{{ $parcela->venda->conveniado->nome_fantasia }}</td>
-            <td>{{ $parcela->status }}</td>
-          </tr>
-        @empty
-          <div class="alert alert-warning" role="alert">
-            Nenhuma parcela vence neste período.
-          </div>
-        @endforelse
-      </tbody>
-    </table>
-  </div>
-  @endcan
+
+    @can('admin')
+
+        <div class="card">
+
+            <form method="get" action="/">
+
+                @include('partials.parcelas-search')
+
+            </form>
+
+            @if (request()->start_date)
+
+                <div class="card-header">
+
+                    <a href="/relatorios/associados?start_date={{ request()->start_date }}
+                    &end_date={{ request()->end_date }}">
+                        
+                        <i class="fas fa-file-pdf"></i> Exportar Relatório PDF
+
+                    </a>
+
+                </div>
+
+            @else
+
+                <div class="alert alert-warning" role="alert">
+
+                    Selecione um período.
+
+                </div>
+
+            @endif
+
+            <table class="table table-striped">
+
+                <thead>
+
+                    <tr>
+
+                        <th><h4>Baixar</h4></th>
+                        <th><h4>Nome</h4></th>
+                        <th><h4>Data</h4></th>
+                        <th><h4>Valor</h4></th>
+                        <th><h4>Conveniado</h4></th>
+                        <th><h4>Status</h4></th>
+
+                    </tr>
+
+                </thead>
+
+                <tbody>
+
+                    @if ($parcelas)
+
+                        @forelse ($parcelas as $parcela)
+
+                            <tr>
+
+                                <td>
+
+                                    @can('admin')
+
+                                        @if( $parcela->status != "Baixado")
+
+                                            <form method="POST" action="/parcelaVenda/{{ $parcela->id }}">
+                                                
+                                                @csrf
+                                                @method('patch')
+                                                <button class="btn btn-primary" onclick="return confirm('Tem certeza que deseja baixar a parcela?');">Baixar parcela</button>
+
+                                            </form>
+                                        
+                                        @endif
+
+                                    @endcan
+
+                                </td>
+                                <td>{{ $parcela->venda->associado->name }}</td>
+                                <td>{{ $parcela->datavencto }}</td>
+                                <td>{{ $parcela->valor }}</td>
+                                <td>{{ $parcela->venda->conveniado->nome_fantasia }}</td>
+                                <td>{{ $parcela->status }}</td>
+
+                            </tr>
+
+                        @empty
+
+                            <div class="alert alert-warning" role="alert">
+                                
+                                Nenhuma parcela vence neste período.
+
+                            </div>
+
+                        @endforelse
+
+                    @endif
+
+                </tbody>
+
+            </table>
+
+        </div>
+
+    @endcan
+
 @endsection

--- a/resources/views/relatorios/conveniados.blade.php
+++ b/resources/views/relatorios/conveniados.blade.php
@@ -3,82 +3,97 @@
 @section('content')
 
   <form method="get" action="/relatorios/conveniados/{{ $conveniado->id }}">
-  @include('partials.parcelas-search')
+    @include('partials.parcelas-search')
   </form>
 
   <div class="card">
 
-  <div class="card-header">
-   <h3 class="card-title">{{ $conveniado->nome_fantasia }}</h3>
-   <div>
-     <a href="/relatorios/conveniados/pdf/{{$conveniado->id}}?start_date={{ request()->start_date }}
-     &end_date={{ request()->end_date }}">
-     <i class="fas fa-file-pdf"></i> Exportar Relatório em PDF</a>
-   </div>
-   <hr>
-   <table class="table">
-     <thead>
-       <tr class="table-active">
-         <th>CNPJ</th>
-         <th>Banco</th>
-         <th>Agência</th>
-         <th>Conta Corrente</th>
-         <th>Tipo de Comissão</th>
-         <th>Comissão</th>
-       </tr>
-     </thead>
-     <tbody>
-         <tr>
-           <td>{{ $conveniado->cnpj }}</td>
-           <td>{{ $conveniado->banco }}</td>
-           <td>{{ $conveniado->agencia }}</td>
-           <td>{{ $conveniado->conta_corrente }}</td>
-           <td>{{ $conveniado->tipo_comissao }}</td>
-           <td>{{ $conveniado->comissao }}</td>
-         </tr>
-      <tbody>
-   </table>
-  </div>
-  <div class="card-body">
-    <table class="table table-striped">
-      <thead>
-        <tr>
-          <th>Data de vencimento</th>
-          <th>Associado</th>
-          <th>Valor</th>
-          <th>Parcela</th>
-        </tr>
-      </thead>
-      @foreach ($parcelas as $parcela)
+    <div class="card-header">
+      <h3 class="card-title">{{ $conveniado->nome_fantasia }}</h3>
+      @if (request()->start_date)
+        <div>
+          <a href="/relatorios/conveniados/pdf/{{$conveniado->id}}?start_date={{ request()->start_date }}
+            &end_date={{ request()->end_date }}">
+            <i class="fas fa-file-pdf"></i> Exportar Relatório em PDF
+          </a>
+        </div>
+      @else
+        <div class="alert alert-warning" role="alert">
+          Selecione um período.
+        </div>
+      @endif
+    </div>
+
+    <div class="card-body">
+      <table class="table">
+        <thead>
+          <tr class="table-active">
+            <th>CNPJ</th>
+            <th>Banco</th>
+            <th>Agência</th>
+            <th>Conta Corrente</th>
+            <th>Tipo de Comissão</th>
+            <th>Comissão</th>
+          </tr>
+        </thead>
         <tbody>
-            <tr>
-              <td>{{ $parcela->datavencto }}</td>
-              <td>{{ $parcela->venda->associado->name }}</td>
-              <td>R$ {{ $parcela->valor }}</td>
-              <td>{{ $parcela->numero }} de {{ $parcela->venda->quantidade_parcelas }}</td>
-            </tr>
-        </tbody>
-      @endforeach
+          <tr>
+            <td>{{ $conveniado->cnpj }}</td>
+            <td>{{ $conveniado->banco }}</td>
+            <td>{{ $conveniado->agencia }}</td>
+            <td>{{ $conveniado->conta_corrente }}</td>
+            <td>{{ $conveniado->tipo_comissao }}</td>
+            <td>{{ $conveniado->comissao }}</td>
+          </tr>
+        <tbody>
       </table>
     </div>
-  <div class="card-body">
-    <table class="table">
-      <thead>
-        <tr class="table-active">
-          <th>Total vendido</th>
-          <th>Comissão FAC</th>
-          <th>Total a pagar</th>
-        </tr>
-      </thead>
-      <tbody>
-          <tr>
-            <td>R$ {{ str_replace('.',',', $parcelas->sum('valor_raw')) }}</td>
-            <td>R$ {{ str_replace('.',',', $parcelas->sum('comissao')) }}</td>
-            <td>R$ {{ str_replace('.',',', ($parcelas->sum('valor_raw') - $parcelas->sum('comissao'))) }}</td>
-          </tr>
-       <tbody>
-    </table>
+    
+    @if ($parcelas)
+      <div class="card-body">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Data de vencimento</th>
+              <th>Associado</th>
+              <th>Valor</th>
+              <th>Parcela</th>
+            </tr>
+          </thead>
+
+          @foreach ($parcelas as $parcela)
+            <tbody>
+              <tr>
+                <td>{{ $parcela->datavencto }}</td>
+                <td>{{ $parcela->venda->associado->name }}</td>
+                <td>R$ {{ $parcela->valor }}</td>
+                <td>{{ $parcela->numero }} de {{ $parcela->venda->quantidade_parcelas }}</td>
+              </tr>
+            </tbody>
+          @endforeach
+        </table>
+      </div>
+
+      <div class="card-body">
+        <table class="table">
+          <thead>
+            <tr class="table-active">
+              <th>Total vendido</th>
+              <th>Comissão FAC</th>
+              <th>Total a pagar</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>R$ {{ str_replace('.',',', $parcelas->sum('valor_raw')) }}</td>
+              <td>R$ {{ str_replace('.',',', $parcelas->sum('comissao')) }}</td>
+              <td>R$ {{ str_replace('.',',', ($parcelas->sum('valor_raw') - $parcelas->sum('comissao'))) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    @endif
+
   </div>
-</div>
 
 @endsection

--- a/resources/views/relatorios/conveniados.blade.php
+++ b/resources/views/relatorios/conveniados.blade.php
@@ -9,46 +9,50 @@
   <div class="card">
 
     <div class="card-header">
-      <h3 class="card-title">{{ $conveniado->nome_fantasia }}</h3>
-      @if (request()->start_date)
-        <div>
-          <a href="/relatorios/conveniados/pdf/{{$conveniado->id}}?start_date={{ request()->start_date }}
-            &end_date={{ request()->end_date }}">
-            <i class="fas fa-file-pdf"></i> Exportar Relatório em PDF
-          </a>
-        </div>
-      @else
-        <div class="alert alert-warning" role="alert">
-          Selecione um período.
-        </div>
-      @endif
+      
+  	 <h3 class="card-title">{{ $conveniado->nome_fantasia }}</h3>
+  	 @if (request()->start_date)
+             <div>
+  	     <a href="/relatorios/conveniados/pdf/{{$conveniado->id}}?start_date={{ request()->start_date }}
+  	       &end_date={{ request()->end_date }}">
+                 <i class="fas fa-file-pdf"></i> Exportar Relatório em PDF
+  	      </a>
+  	    </div>
+  	  @else
+              <div class="alert alert-warning" role="alert">
+                Selecione um período.
+  	    </div>
+  	  @endif
+
+      <div class="card-body">
+
+        <table class="table">
+          <thead>
+            <tr class="table-active">
+              <th>CNPJ</th>
+              <th>Banco</th>
+              <th>Agência</th>
+              <th>Conta Corrente</th>
+              <th>Tipo de Comissão</th>
+              <th>Comissão</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{{ $conveniado->cnpj }}</td>
+              <td>{{ $conveniado->banco }}</td>
+              <td>{{ $conveniado->agencia }}</td>
+              <td>{{ $conveniado->conta_corrente }}</td>
+              <td>{{ $conveniado->tipo_comissao }}</td>
+              <td>{{ $conveniado->comissao }}</td>
+            </tr>
+          <tbody>
+        </table>
+
+      </div>
+
     </div>
 
-    <div class="card-body">
-      <table class="table">
-        <thead>
-          <tr class="table-active">
-            <th>CNPJ</th>
-            <th>Banco</th>
-            <th>Agência</th>
-            <th>Conta Corrente</th>
-            <th>Tipo de Comissão</th>
-            <th>Comissão</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{{ $conveniado->cnpj }}</td>
-            <td>{{ $conveniado->banco }}</td>
-            <td>{{ $conveniado->agencia }}</td>
-            <td>{{ $conveniado->conta_corrente }}</td>
-            <td>{{ $conveniado->tipo_comissao }}</td>
-            <td>{{ $conveniado->comissao }}</td>
-          </tr>
-        <tbody>
-      </table>
-    </div>
-    
     @if ($parcelas)
       <div class="card-body">
         <table class="table table-striped">


### PR DESCRIPTION
Uma solução para resolver a questão do período padrão na barra de pesquisa por parcelas. A ideia aqui é indicar explicitamente que é necessário selecionar um período, para que então a query seja realizada.