### PR TITLE
Arrumando tela de cadastrar

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,6 +30,6 @@ class AppServiceProvider extends ServiceProvider
         //}
         if (env('FORCE_HTTPS')) {
             \URL::forceScheme('https');
-        }
+     }
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -61,7 +61,7 @@ class AuthServiceProvider extends ServiceProvider
             }
             return false;
         });
-
+        
         // associado owner
         Gate::define('associado.owner', function ($user, $associado_id) {
 

--- a/app/Rules/SaldoDisponivel.php
+++ b/app/Rules/SaldoDisponivel.php
@@ -26,6 +26,7 @@ class SaldoDisponivel implements Rule
      */
     public function passes($attribute, $value)
     {
+
         $associado = self::associado(request()->get('associado_id'));
         $saldo = $associado->saldo();
         

--- a/resources/views/associados/form.blade.php
+++ b/resources/views/associados/form.blade.php
@@ -191,22 +191,6 @@
 
 <hr>
 
-<div class="card">
-    <div class="card-header"><b> Nova senha </b></div>
-    <div class="card-body">
-        <div class="col-sm form-group">
-            <div class="form-group">
-                <label for="password" class="required"><b>Senha: </b></label>
-                <br>
-                <small>Deixe este campo em branco para não mudar a senha.</small>
-                <input type="password" class="form-control" id="password" name="password">
-            </div>
-        </div>
-    </div>
-</div>
-
-<hr>
-
 <div class="form-group">
     <button type="submit" class="btn btn-success">Enviar</button>
 </div>

--- a/resources/views/associados/form.blade.php
+++ b/resources/views/associados/form.blade.php
@@ -1,5 +1,3 @@
-@inject('replicado','App\Utils\ReplicadoUtils')
-
 <div class="card">
 <div class="card-header"><h4><b>Cadastro de Associado</b></h4></div>
 <hr>
@@ -17,14 +15,6 @@
             <div class="col-sm form-group">
                 <label for="unidade" class="required"><b>Unidade: </b></label>
                     <input type="text" class="form-control" id="unidade" name="unidade" value="{{old('unidade',$associado->unidade)}}">
-                    <!--
-                        Teste de como pegar o replicado
-                        <select class="form-control" name="unidade">
-                        @foreach($replicado::unidades() as $unidade)
-                          <option value="{$replicado->codund}">{{$unidade}}</option>
-                        @endforeach
-                    </select>
-                    -->
             </div>
 
             <div class="col-sm form-group">
@@ -194,6 +184,22 @@
                     <label for="banco" class="required"><b>Limite: </b></label>
                     <input type="text" class="form-control" id="limite" name="limite" value="{{ $associado->limite ? (old('limite') ? old('limite') : $associado->limite) : '200' }}">
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<hr>
+
+<div class="card">
+    <div class="card-header"><b> Nova senha </b></div>
+    <div class="card-body">
+        <div class="col-sm form-group">
+            <div class="form-group">
+                <label for="password" class="required"><b>Senha: </b></label>
+                <br>
+                <small>Deixe este campo em branco para não mudar a senha.</small>
+                <input type="password" class="form-control" id="password" name="password">
             </div>
         </div>
     </div>

--- a/resources/views/vendas/show.blade.php
+++ b/resources/views/vendas/show.blade.php
@@ -37,7 +37,7 @@
 
             </div>
         </div>
-
+        
         <ul class="list-group">
         @foreach($venda->parcelas as $parcela)
             <li class="list-group-item" style="display: flex; justify-content: space-between;">


### PR DESCRIPTION
Foram retiradas partes do código que capturavam dados dentro do replicado, nesse caso o dado era a unidade, para a página ser exibida corretamente. A classe ReplicadoUtils não foi excluída pois um dos arquivos blades das vendas utiliza a mesma. 